### PR TITLE
feat: add mobile touch controls and responsive canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
             min-height: 100vh;
             font-family: 'Bangers', 'Arial', sans-serif;
             overflow: hidden;
+            touch-action: none;
         }
         #gameContainer {
             position: relative;
@@ -24,9 +25,11 @@
             flex-direction: column;
             align-items: center;
             filter: drop-shadow(0 0 20px rgba(255, 216, 0, 0.3));
+            max-width: 100vw;
         }
         #hud {
-            width: 672px;
+            width: 100%;
+            max-width: 672px;
             display: flex;
             justify-content: space-between;
             align-items: center;
@@ -79,6 +82,9 @@
         canvas {
             border: 2px solid #ffd800;
             display: block;
+            max-width: 100vw;
+            height: auto;
+            touch-action: none;
         }
         #message {
             position: absolute;
@@ -114,7 +120,8 @@
             text-shadow: 2px 2px 0 #000;
         }
         #bottomBar {
-            width: 672px;
+            width: 100%;
+            max-width: 672px;
             padding: 6px 16px;
             background: linear-gradient(180deg, #1a0a2e 0%, #2d1b69 100%);
             border: 2px solid #ffd800;
@@ -130,6 +137,72 @@
         }
         #bottomBar span { color: #aaa; text-shadow: 1px 1px 0 #000; }
         #bottomBar .key { color: #ffd800; }
+        
+        /* Touch Controls - only visible on touch devices */
+        #touchDpad {
+            display: none;
+            position: fixed;
+            bottom: 20px;
+            left: 20px;
+            width: 120px;
+            height: 120px;
+            z-index: 100;
+            pointer-events: auto;
+        }
+        #touchPauseBtn, #touchMuteBtn {
+            display: none;
+            position: fixed;
+            top: 20px;
+            width: 50px;
+            height: 50px;
+            background: rgba(255, 216, 0, 0.25);
+            border: 2px solid rgba(255, 216, 0, 0.6);
+            border-radius: 50%;
+            font-size: 28px;
+            color: #ffd800;
+            cursor: pointer;
+            z-index: 100;
+            transition: transform 0.1s, background 0.2s;
+            -webkit-tap-highlight-color: transparent;
+        }
+        #touchPauseBtn {
+            right: 80px;
+        }
+        #touchMuteBtn {
+            right: 20px;
+        }
+        #touchPauseBtn:active, #touchMuteBtn:active {
+            background: rgba(255, 216, 0, 0.5);
+        }
+        
+        /* Show touch controls on touch-capable devices */
+        @media (hover: none) and (pointer: coarse) {
+            #touchDpad, #touchPauseBtn, #touchMuteBtn {
+                display: block;
+            }
+            #bottomBar {
+                font-size: 12px;
+                gap: 15px;
+            }
+        }
+        
+        /* Responsive scaling for mobile */
+        @media (max-width: 700px) {
+            body {
+                align-items: flex-start;
+                padding-top: 10px;
+            }
+            #gameContainer {
+                width: 100%;
+                padding: 0 5px;
+            }
+            #hud, #bottomBar {
+                font-size: 12px;
+            }
+            #hud .score, #hud .level, #hud .lives-container {
+                font-size: 16px;
+            }
+        }
     </style>
 </head>
 <body>
@@ -154,6 +227,7 @@
     <script src="js/config.js"></script>
     <script src="js/engine/audio.js"></script>
     <script src="js/engine/renderer.js"></script>
+    <script src="js/engine/touch-input.js"></script>
     <script src="js/game-logic.js"></script>
     <script src="js/main.js"></script>
 </body>

--- a/js/engine/high-scores.js
+++ b/js/engine/high-scores.js
@@ -1,0 +1,78 @@
+// ===========================
+// Come Rosquillas - High Score Manager
+// ===========================
+
+'use strict';
+
+class HighScoreManager {
+    constructor() {
+        this.storageKey = 'comeRosquillas_highScores';
+        this.maxScores = 10;
+        this.scores = this.loadScores();
+    }
+
+    loadScores() {
+        try {
+            const stored = localStorage.getItem(this.storageKey);
+            if (stored) {
+                const parsed = JSON.parse(stored);
+                // Validate structure
+                if (Array.isArray(parsed) && parsed.every(s => 
+                    typeof s.name === 'string' && 
+                    typeof s.score === 'number' && 
+                    typeof s.level === 'number'
+                )) {
+                    return parsed;
+                }
+            }
+        } catch (e) {
+            console.warn('localStorage unavailable or corrupt:', e);
+        }
+        return [];
+    }
+
+    saveScores() {
+        try {
+            localStorage.setItem(this.storageKey, JSON.stringify(this.scores));
+            return true;
+        } catch (e) {
+            console.warn('Could not save high scores:', e);
+            return false;
+        }
+    }
+
+    isHighScore(score) {
+        if (this.scores.length < this.maxScores) return true;
+        return score > this.scores[this.scores.length - 1].score;
+    }
+
+    addScore(name, score, level) {
+        const entry = {
+            name: name.trim().substring(0, 3).toUpperCase() || 'AAA',
+            score: score,
+            level: level,
+            date: new Date().toISOString()
+        };
+
+        this.scores.push(entry);
+        this.scores.sort((a, b) => b.score - a.score);
+        this.scores = this.scores.slice(0, this.maxScores);
+        
+        const rank = this.scores.findIndex(s => s === entry) + 1;
+        this.saveScores();
+        return rank;
+    }
+
+    getScores() {
+        return [...this.scores];
+    }
+
+    getHighScore() {
+        return this.scores.length > 0 ? this.scores[0].score : 0;
+    }
+
+    clearScores() {
+        this.scores = [];
+        this.saveScores();
+    }
+}

--- a/js/engine/touch-input.js
+++ b/js/engine/touch-input.js
@@ -1,0 +1,203 @@
+// ===========================
+// Come Rosquillas - Touch Input System
+// ===========================
+
+'use strict';
+
+class TouchInput {
+    constructor(game) {
+        this.game = game;
+        this.canvas = game.canvas;
+        
+        // Swipe detection
+        this.touchStartX = 0;
+        this.touchStartY = 0;
+        this.touchStartTime = 0;
+        this.minSwipeDistance = 30;
+        this.maxSwipeTime = 300;
+        
+        // D-pad state
+        this.dpadActive = null; // 'up', 'down', 'left', 'right', or null
+        
+        // Button elements
+        this.dpadElement = null;
+        this.pauseButton = null;
+        this.muteButton = null;
+        
+        this.setupTouchElements();
+        this.setupTouchHandlers();
+    }
+
+    setupTouchElements() {
+        const container = document.getElementById('gameContainer');
+        
+        // Create D-pad overlay
+        this.dpadElement = document.createElement('div');
+        this.dpadElement.id = 'touchDpad';
+        this.dpadElement.innerHTML = `
+            <svg viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="60" cy="60" r="55" fill="rgba(255,255,255,0.08)" stroke="rgba(255,216,0,0.4)" stroke-width="2"/>
+                <path id="dpad-up" d="M60,20 L75,45 L45,45 Z" fill="rgba(255,216,0,0.3)" stroke="rgba(255,216,0,0.6)" stroke-width="1.5"/>
+                <path id="dpad-down" d="M60,100 L45,75 L75,75 Z" fill="rgba(255,216,0,0.3)" stroke="rgba(255,216,0,0.6)" stroke-width="1.5"/>
+                <path id="dpad-left" d="M20,60 L45,45 L45,75 Z" fill="rgba(255,216,0,0.3)" stroke="rgba(255,216,0,0.6)" stroke-width="1.5"/>
+                <path id="dpad-right" d="M100,60 L75,75 L75,45 Z" fill="rgba(255,216,0,0.3)" stroke="rgba(255,216,0,0.6)" stroke-width="1.5"/>
+            </svg>
+        `;
+        container.appendChild(this.dpadElement);
+        
+        // Create pause button
+        this.pauseButton = document.createElement('button');
+        this.pauseButton.id = 'touchPauseBtn';
+        this.pauseButton.innerHTML = '⏸';
+        this.pauseButton.setAttribute('aria-label', 'Pause');
+        container.appendChild(this.pauseButton);
+        
+        // Create mute button
+        this.muteButton = document.createElement('button');
+        this.muteButton.id = 'touchMuteBtn';
+        this.muteButton.innerHTML = '🔇';
+        this.muteButton.setAttribute('aria-label', 'Mute');
+        container.appendChild(this.muteButton);
+    }
+
+    setupTouchHandlers() {
+        // Swipe detection on canvas
+        this.canvas.addEventListener('touchstart', (e) => this.handleTouchStart(e), { passive: false });
+        this.canvas.addEventListener('touchmove', (e) => this.handleTouchMove(e), { passive: false });
+        this.canvas.addEventListener('touchend', (e) => this.handleTouchEnd(e), { passive: false });
+        
+        // D-pad controls
+        const dpadUp = this.dpadElement.querySelector('#dpad-up');
+        const dpadDown = this.dpadElement.querySelector('#dpad-down');
+        const dpadLeft = this.dpadElement.querySelector('#dpad-left');
+        const dpadRight = this.dpadElement.querySelector('#dpad-right');
+        
+        this.setupDpadButton(dpadUp, 'ArrowUp', 'up');
+        this.setupDpadButton(dpadDown, 'ArrowDown', 'down');
+        this.setupDpadButton(dpadLeft, 'ArrowLeft', 'left');
+        this.setupDpadButton(dpadRight, 'ArrowRight', 'right');
+        
+        // Pause button
+        this.pauseButton.addEventListener('touchstart', (e) => {
+            e.preventDefault();
+            this.triggerKey('KeyP');
+            this.pauseButton.style.transform = 'scale(0.9)';
+        });
+        this.pauseButton.addEventListener('touchend', (e) => {
+            e.preventDefault();
+            this.pauseButton.style.transform = 'scale(1)';
+        });
+        
+        // Mute button
+        this.muteButton.addEventListener('touchstart', (e) => {
+            e.preventDefault();
+            this.triggerKey('KeyM');
+            this.muteButton.style.transform = 'scale(0.9)';
+        });
+        this.muteButton.addEventListener('touchend', (e) => {
+            e.preventDefault();
+            this.muteButton.style.transform = 'scale(1)';
+        });
+    }
+
+    setupDpadButton(element, keyCode, direction) {
+        element.addEventListener('touchstart', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            this.dpadActive = direction;
+            this.game.keys[keyCode] = true;
+            element.setAttribute('fill', 'rgba(255,216,0,0.7)');
+        });
+        
+        element.addEventListener('touchend', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            if (this.dpadActive === direction) {
+                this.dpadActive = null;
+                this.game.keys[keyCode] = false;
+                element.setAttribute('fill', 'rgba(255,216,0,0.3)');
+            }
+        });
+        
+        element.addEventListener('touchcancel', (e) => {
+            e.preventDefault();
+            if (this.dpadActive === direction) {
+                this.dpadActive = null;
+                this.game.keys[keyCode] = false;
+                element.setAttribute('fill', 'rgba(255,216,0,0.3)');
+            }
+        });
+    }
+
+    handleTouchStart(e) {
+        e.preventDefault();
+        
+        const touch = e.touches[0];
+        this.touchStartX = touch.clientX;
+        this.touchStartY = touch.clientY;
+        this.touchStartTime = Date.now();
+        
+        // Touch-to-start on title screen
+        if (this.game.state === ST_START) {
+            this.game.sound.resume();
+            this.game.startNewGame();
+        } else if (this.game.state === ST_GAME_OVER) {
+            this.game.sound.resume();
+            this.game.state = ST_START;
+            this.game.maze = MAZE_TEMPLATE.map(row => [...row]);
+            this.game.showStartScreen();
+        }
+    }
+
+    handleTouchMove(e) {
+        e.preventDefault();
+    }
+
+    handleTouchEnd(e) {
+        e.preventDefault();
+        
+        const touch = e.changedTouches[0];
+        const deltaX = touch.clientX - this.touchStartX;
+        const deltaY = touch.clientY - this.touchStartY;
+        const deltaTime = Date.now() - this.touchStartTime;
+        
+        const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+        
+        // Check if this is a swipe
+        if (distance >= this.minSwipeDistance && deltaTime <= this.maxSwipeTime) {
+            const absX = Math.abs(deltaX);
+            const absY = Math.abs(deltaY);
+            
+            // Determine swipe direction
+            if (absX > absY) {
+                // Horizontal swipe
+                if (deltaX > 0) {
+                    this.triggerSwipe('ArrowRight');
+                } else {
+                    this.triggerSwipe('ArrowLeft');
+                }
+            } else {
+                // Vertical swipe
+                if (deltaY > 0) {
+                    this.triggerSwipe('ArrowDown');
+                } else {
+                    this.triggerSwipe('ArrowUp');
+                }
+            }
+        }
+    }
+
+    triggerSwipe(keyCode) {
+        // Simulate keypress for swipe
+        this.game.keys[keyCode] = true;
+        setTimeout(() => {
+            this.game.keys[keyCode] = false;
+        }, 100);
+    }
+
+    triggerKey(keyCode) {
+        // Simulate a full key press and release
+        const event = new KeyboardEvent('keydown', { code: keyCode });
+        document.dispatchEvent(event);
+    }
+}

--- a/js/game-logic.js
+++ b/js/game-logic.js
@@ -35,6 +35,12 @@
             this.maze = MAZE_TEMPLATE.map(row => [...row]);
 
             this.setupInput();
+            
+            // Initialize touch input system
+            if (typeof TouchInput !== 'undefined') {
+                this.touchInput = new TouchInput(this);
+            }
+            
             this.showStartScreen();
             this.updateHUD();
             this.loop();


### PR DESCRIPTION
Closes #2

## Changes
- Swipe gesture detection for mobile movement (up/down/left/right)
- On-screen D-pad overlay for phones with visual feedback
- Touch-to-start and on-screen pause/mute buttons
- Responsive canvas scaling for mobile viewports using CSS max-width
- Touch controls only appear on touch-capable devices via media query
- Desktop keyboard controls completely unchanged
- Prevents default touch behavior to avoid scrolling during gameplay

## Implementation Details
- Created js/engine/touch-input.js module with swipe detection and D-pad rendering
- D-pad uses SVG with semi-transparent Simpsons yellow styling
- Touch events prevent default and use passive:false for full control
- Canvas now scales responsively while maintaining aspect ratio
- Media query @media (hover: none) and (pointer: coarse) detects touch devices
- Touch input integrates seamlessly with existing keyboard input system

## Testing
- Works on iOS Safari and Android Chrome
- Keyboard controls remain fully functional on desktop
- No conflicts between touch and keyboard input