### PR TITLE
Redesign D-pad: classic cross/plus shape replaces triangular arrows

### DIFF
--- a/index.html
+++ b/index.html
@@ -871,18 +871,50 @@
             justify-items: center;
         }
 
-        /* D-pad — hidden by default, shown on touch devices */
+        /* D-pad — classic cross/plus shape, hidden by default */
         #touchDpad {
             display: none;
             width: 160px;
             height: 160px;
             pointer-events: auto;
         }
-        #touchDpad svg { width: 100%; height: 100%; }
-        .dpad-arrow { transition: fill 0.08s, filter 0.08s; }
+        .dpad-cross {
+            display: grid;
+            grid-template-columns: 1fr 1fr 1fr;
+            grid-template-rows: 1fr 1fr 1fr;
+            width: 100%;
+            height: 100%;
+            gap: 2px;
+        }
+        .dpad-btn {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: rgba(255,216,0,0.2);
+            border: 1.5px solid rgba(255,216,0,0.5);
+            color: rgba(255,216,0,0.8);
+            font-size: 18px;
+            user-select: none;
+            -webkit-user-select: none;
+            touch-action: none;
+            cursor: pointer;
+            transition: background 0.08s, box-shadow 0.08s;
+            border-radius: 6px;
+        }
+        .dpad-up    { grid-column: 2; grid-row: 1; border-radius: 6px 6px 0 0; }
+        .dpad-left  { grid-column: 1; grid-row: 2; border-radius: 6px 0 0 6px; }
+        .dpad-center {
+            grid-column: 2; grid-row: 2;
+            background: rgba(255,216,0,0.12);
+            border: 1.5px solid rgba(255,216,0,0.3);
+            border-radius: 0;
+        }
+        .dpad-right { grid-column: 3; grid-row: 2; border-radius: 0 6px 6px 0; }
+        .dpad-down  { grid-column: 2; grid-row: 3; border-radius: 0 0 6px 6px; }
         .dpad-active {
-            fill: rgba(255,216,0,0.85) !important;
-            filter: drop-shadow(0 0 8px rgba(255,216,0,0.9));
+            background: rgba(255,216,0,0.7) !important;
+            box-shadow: 0 0 12px rgba(255,216,0,0.9);
+            color: #1a0a3a;
         }
 
         /* Virtual joystick — hidden by default, shown on touch devices */

--- a/js/engine/touch-input.js
+++ b/js/engine/touch-input.js
@@ -105,17 +105,17 @@ class TouchInput {
         this.controlsBar = document.createElement('div')
         this.controlsBar.id = 'touchControlsBar'
 
-        // D-pad — large SVG touch targets
+        // D-pad — classic cross/plus shape (Game Boy style)
         this.dpadElement = document.createElement('div')
         this.dpadElement.id = 'touchDpad'
         this.dpadElement.innerHTML = `
-            <svg viewBox="0 0 160 160" xmlns="http://www.w3.org/2000/svg">
-                <circle cx="80" cy="80" r="75" fill="rgba(255,255,255,0.08)" stroke="rgba(255,216,0,0.4)" stroke-width="2"/>
-                <path id="dpad-up" d="M80,15 L105,55 L55,55 Z" fill="rgba(255,216,0,0.3)" stroke="rgba(255,216,0,0.6)" stroke-width="1.5" class="dpad-arrow"/>
-                <path id="dpad-down" d="M80,145 L55,105 L105,105 Z" fill="rgba(255,216,0,0.3)" stroke="rgba(255,216,0,0.6)" stroke-width="1.5" class="dpad-arrow"/>
-                <path id="dpad-left" d="M15,80 L55,55 L55,105 Z" fill="rgba(255,216,0,0.3)" stroke="rgba(255,216,0,0.6)" stroke-width="1.5" class="dpad-arrow"/>
-                <path id="dpad-right" d="M145,80 L105,105 L105,55 Z" fill="rgba(255,216,0,0.3)" stroke="rgba(255,216,0,0.6)" stroke-width="1.5" class="dpad-arrow"/>
-            </svg>
+            <div class="dpad-cross">
+                <div id="dpad-up" class="dpad-btn dpad-up">▲</div>
+                <div id="dpad-left" class="dpad-btn dpad-left">◄</div>
+                <div class="dpad-center"></div>
+                <div id="dpad-right" class="dpad-btn dpad-right">►</div>
+                <div id="dpad-down" class="dpad-btn dpad-down">▼</div>
+            </div>
         `
         this.controlsBar.appendChild(this.dpadElement)
 


### PR DESCRIPTION
## Summary

Replaces the triangular SVG arrow buttons in the D-pad fallback control with a classic Game Boy-style cross/plus shape using CSS Grid.

### Changes
- **touch-input.js**: Replaced SVG \<path>\ triangles with a div-based 3x3 grid layout (only cross cells filled)
- **index.html**: New CSS for the cross-shaped D-pad — large rectangular touch zones (~53px each), clear visual separation, active-state highlight

### Why
The triangular buttons were hard to press accurately with a finger on mobile. The cross shape provides larger, more predictable touch targets — just like a Game Boy D-pad.

### Testing
- Event dispatching unchanged (same element IDs, same handlers)
- Works in both portrait and landscape orientations
- \
pm test\: 2530/2532 tests pass (2 pre-existing zod failures in docs/)

Closes #0